### PR TITLE
Bump log4j-api from 2.11.2 to 2.16.0 in /log4j2

### DIFF
--- a/log4j2/pom.xml
+++ b/log4j2/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <log4j.version>2.11.2</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
         <disruptor.version>3.4.2</disruptor.version>
         <jackson.version>2.9.8</jackson.version>
     </properties>


### PR DESCRIPTION
Bumps log4j-api from 2.11.2 to 2.16.0.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-api dependency-type: direct:production ...